### PR TITLE
Add timestamp to CSV output for use in future reporting/graphing

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -29,6 +29,7 @@ import threading
 import re
 import signal
 import socket
+import datetime
 
 # Used for bound_interface
 socket_socket = socket.socket
@@ -596,6 +597,8 @@ def speedtest():
                    '%(latency)s ms' % best)
     else:
         if args.csv:
+            reporttime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            print_('%s,' % reporttime, end='')
             print_('%(latency)s,' % best, end='')
         else:
             print_('Ping: %(latency)s ms' % best)


### PR DESCRIPTION
Add a timestamp as a first column to the CSV output so that it can be incorporated into future reporting/graphing that one might send to one's ISP customer service rep who is denying that there's a problem with available speeds dropping dramatically during peak usage hours.